### PR TITLE
Implement WebGPU slime mould simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>WebGPU Demo</title>
+    <title>Slime Mould Simulation - WebGPU</title>
     <style>
         * {
             margin: 0;
@@ -24,28 +24,84 @@
             height: 100vh;
         }
 
-        .overlay {
+        .controls {
             position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            text-align: center;
-            pointer-events: none;
+            top: 20px;
+            right: 20px;
+            background: rgba(0, 0, 0, 0.7);
+            padding: 20px;
+            border-radius: 8px;
+            backdrop-filter: blur(10px);
+            max-width: 300px;
+            max-height: calc(100vh - 40px);
+            overflow-y: auto;
             z-index: 10;
         }
 
-        h1 {
-            font-size: clamp(2rem, 8vw, 6rem);
-            font-weight: 300;
-            letter-spacing: -0.02em;
-            margin-bottom: 1rem;
-            text-shadow: 0 2px 20px rgba(0, 0, 0, 0.3);
+        .controls h2 {
+            font-size: 1.2rem;
+            margin-bottom: 15px;
+            font-weight: 500;
         }
 
-        p {
-            font-size: clamp(0.875rem, 2vw, 1.125rem);
-            opacity: 0.7;
-            font-weight: 300;
+        .control-group {
+            margin-bottom: 15px;
+        }
+
+        .control-group label {
+            display: block;
+            font-size: 0.85rem;
+            margin-bottom: 5px;
+            opacity: 0.8;
+        }
+
+        .control-group input[type="range"] {
+            width: 100%;
+            height: 4px;
+            border-radius: 2px;
+            background: rgba(255, 255, 255, 0.2);
+            outline: none;
+        }
+
+        .control-group input[type="range"]::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #fff;
+            cursor: pointer;
+        }
+
+        .control-group input[type="range"]::-moz-range-thumb {
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: #fff;
+            cursor: pointer;
+            border: none;
+        }
+
+        .control-group .value {
+            font-size: 0.75rem;
+            opacity: 0.6;
+            margin-top: 2px;
+        }
+
+        button {
+            width: 100%;
+            padding: 10px;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            color: #fff;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.85rem;
+            margin-top: 10px;
+        }
+
+        button:hover {
+            background: rgba(255, 255, 255, 0.15);
         }
 
         .error {
@@ -63,26 +119,130 @@
             color: #ff6b6b;
         }
 
-        .error p {
-            opacity: 1;
-            line-height: 1.6;
+        .info {
+            position: absolute;
+            bottom: 20px;
+            left: 20px;
+            font-size: 0.85rem;
+            opacity: 0.5;
         }
     </style>
 </head>
 <body>
     <canvas id="canvas"></canvas>
-    <div class="overlay">
-        <h1>WebGPU</h1>
-        <p>Animated gradient powered by WebGPU</p>
+
+    <div class="controls">
+        <h2>Slime Mould</h2>
+
+        <div class="control-group">
+            <label>Sensing Distance: <span class="value" id="sensingDistanceValue">20</span></label>
+            <input type="range" id="sensingDistance" min="5" max="100" value="20" step="1">
+        </div>
+
+        <div class="control-group">
+            <label>Sensing Angle: <span class="value" id="sensingAngleValue">0.52</span></label>
+            <input type="range" id="sensingAngle" min="0" max="3.14" value="0.52" step="0.01">
+        </div>
+
+        <div class="control-group">
+            <label>Turning Angle: <span class="value" id="turningAngleValue">0.52</span></label>
+            <input type="range" id="turningAngle" min="0" max="3.14" value="0.52" step="0.01">
+        </div>
+
+        <div class="control-group">
+            <label>Deposit Amount: <span class="value" id="depositAmountValue">0.10</span></label>
+            <input type="range" id="depositAmount" min="0" max="1" value="0.10" step="0.01">
+        </div>
+
+        <div class="control-group">
+            <label>Decay Amount: <span class="value" id="decayAmountValue">0.10</span></label>
+            <input type="range" id="decayAmount" min="0" max="1" value="0.10" step="0.01">
+        </div>
+
+        <div class="control-group">
+            <label>Step Size: <span class="value" id="stepSizeValue">1.0</span></label>
+            <input type="range" id="stepSize" min="0.1" max="5" value="1.0" step="0.1">
+        </div>
+
+        <button id="resetButton">Reset Simulation</button>
+    </div>
+
+    <div class="info">
+        WebGPU Physarum Simulation | <span id="fps">0</span> FPS
     </div>
 
     <script>
+        const AGENT_COUNT = 1024 * 256; // 262,144 agents
+        const WORKGROUP_SIZE = 128;
+
+        const params = {
+            sensingDistance: 20,
+            sensingAngle: 0.52,
+            turningAngle: 0.52,
+            depositAmount: 0.10,
+            decayAmount: 0.10,
+            stepSize: 1.0
+        };
+
+        function setupControls(resetCallback) {
+            const controls = ['sensingDistance', 'sensingAngle', 'turningAngle',
+                            'depositAmount', 'decayAmount', 'stepSize'];
+
+            controls.forEach(name => {
+                const slider = document.getElementById(name);
+                const valueDisplay = document.getElementById(name + 'Value');
+                slider.addEventListener('input', (e) => {
+                    params[name] = parseFloat(e.target.value);
+                    valueDisplay.textContent = params[name].toFixed(2);
+                });
+            });
+
+            document.getElementById('resetButton').addEventListener('click', resetCallback);
+        }
+
+        function initAgents(width, height) {
+            const agentData = new Float32Array(AGENT_COUNT * 6);
+
+            // Initialize agents in center with random colors
+            const centerX = width / 2;
+            const centerY = height / 2;
+            const radius = Math.min(width, height) * 0.2;
+
+            for (let i = 0; i < AGENT_COUNT; i++) {
+                const idx = i * 6;
+
+                // Position - radial distribution from center
+                const angle = Math.random() * Math.PI * 2;
+                const r = Math.sqrt(Math.random()) * radius;
+                agentData[idx + 0] = centerX + Math.cos(angle) * r; // x
+                agentData[idx + 1] = centerY + Math.sin(angle) * r; // y
+
+                // Angle
+                agentData[idx + 2] = Math.random() * Math.PI * 2;
+
+                // Color - 4 different colors for variety
+                const colorGroup = Math.floor(Math.random() * 4);
+                const hue = colorGroup * 0.25; // 0, 0.25, 0.5, 0.75
+                const rgb = hsv2rgb(hue, 1.0, 1.0);
+                agentData[idx + 3] = rgb[0]; // r
+                agentData[idx + 4] = rgb[1]; // g
+                agentData[idx + 5] = rgb[2]; // b
+            }
+
+            return agentData;
+        }
+
+        function hsv2rgb(h, s, v) {
+            const k = (n) => (n + h * 6) % 6;
+            const f = (n) => v - v * s * Math.max(0, Math.min(k(n), 4 - k(n), 1));
+            return [f(5), f(3), f(1)];
+        }
+
         async function initWebGPU() {
             const canvas = document.getElementById('canvas');
 
-            // Check for WebGPU support
             if (!navigator.gpu) {
-                showError('WebGPU is not supported in your browser. Try Chrome 113+, Edge 113+, or Safari 18+ on macOS.');
+                showError('WebGPU is not supported in your browser. Try Chrome 113+, Edge 113+, or Safari 18+.');
                 return;
             }
 
@@ -96,30 +256,212 @@
             const context = canvas.getContext('webgpu');
             const format = navigator.gpu.getPreferredCanvasFormat();
 
+            // Simulation resolution
+            const simWidth = 1920;
+            const simHeight = 1080;
+
             // Set canvas size
-            // Set canvas size and reconfigure WebGPU context
-            function resizeCanvas() {
-                canvas.width = window.innerWidth * devicePixelRatio;
-                canvas.height = window.innerHeight * devicePixelRatio;
-                context.configure({
-                    device,
-                    format,
-                    alphaMode: 'opaque',
-                });
-            }
-            resizeCanvas();
-            window.addEventListener('resize', resizeCanvas);
-            // Shader code
-            const shaderCode = `
-                struct Uniforms {
-                    time: f32,
-                    width: f32,
-                    height: f32,
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+
+            context.configure({
+                device,
+                format,
+                alphaMode: 'opaque',
+            });
+
+            // Shared shader code
+            const shaderCommon = `
+                struct Parameters {
+                    frameBufferWidth: f32,
+                    frameBufferHeight: f32,
+                    sensingDistance: f32,
+                    sensingAngle: f32,
+                    turningAngle: f32,
+                    depositAmount: f32,
+                    decayAmount: f32,
+                    stepSize: f32,
                 }
-                @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+                struct Agent {
+                    x: f32,
+                    y: f32,
+                    angle: f32,
+                    r: f32,
+                    g: f32,
+                    b: f32,
+                }
+
+                @group(0) @binding(0) var agentMap: texture_storage_2d<rgba32float, read>;
+                @group(0) @binding(1) var agentMapOut: texture_storage_2d<rgba32float, write>;
+                @group(0) @binding(2) var trailMap: texture_storage_2d<rgba32float, read>;
+                @group(0) @binding(3) var trailMapOut: texture_storage_2d<rgba32float, write>;
+                @group(0) @binding(4) var<storage, read> params: Parameters;
+                @group(0) @binding(5) var<storage, read_write> agents: array<Agent>;
+
+                fn hash(state: u32) -> f32 {
+                    var s = state;
+                    s ^= 2747636419u;
+                    s *= 2654435769u;
+                    s ^= s >> 16;
+                    s *= 2654435769u;
+                    s ^= s >> 16;
+                    s *= 2654435769u;
+                    return f32(s) / 4294967295.0;
+                }
+
+                fn rgb2hsv(c: vec3f) -> vec3f {
+                    let K = vec4f(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+                    let p = mix(vec4f(c.bg, K.wz), vec4f(c.gb, K.xy), select(0.0, 1.0, c.b < c.g));
+                    let q = mix(vec4f(p.xyw, c.r), vec4f(c.r, p.yzx), select(0.0, 1.0, p.x < c.r));
+                    let d = q.x - min(q.w, q.y);
+                    let e = 1.0e-10;
+                    return vec3f(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+                }
+
+                fn hsv2rgb(c: vec3f) -> vec3f {
+                    let K = vec4f(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                    let p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+                    return c.z * mix(K.xxx, clamp(p - K.xxx, vec3f(0.0), vec3f(1.0)), c.y);
+                }
+            `;
+
+            // Stage 0: Agent update
+            const computeShaderStage0 = shaderCommon + `
+                @compute @workgroup_size(${WORKGROUP_SIZE}, 1, 1)
+                fn main(@builtin(global_invocation_id) global_id: vec3u) {
+                    let gid = global_id.x;
+                    if (gid >= ${AGENT_COUNT}u) {
+                        return;
+                    }
+
+                    let width = u32(params.frameBufferWidth);
+                    let height = u32(params.frameBufferHeight);
+                    let angle = agents[gid].angle;
+                    let position = vec2f(agents[gid].x, agents[gid].y);
+                    let pixel = vec2i(i32(position.x), i32(position.y));
+
+                    let sensingDistance = params.sensingDistance;
+                    let sensingAngle = params.sensingAngle;
+                    let sensor_front = vec2f(
+                        (position.x + sensingDistance * cos(angle)) % f32(width),
+                        (position.y + sensingDistance * sin(angle)) % f32(height)
+                    );
+                    let sensor_left = vec2f(
+                        (position.x + sensingDistance * cos(angle + sensingAngle)) % f32(width),
+                        (position.y + sensingDistance * sin(angle + sensingAngle)) % f32(height)
+                    );
+                    let sensor_right = vec2f(
+                        (position.x + sensingDistance * cos(angle - sensingAngle)) % f32(width),
+                        (position.y + sensingDistance * sin(angle - sensingAngle)) % f32(height)
+                    );
+
+                    let sensor_front_pos = vec2i(i32(sensor_front.x), i32(sensor_front.y));
+                    let sensor_left_pos = vec2i(i32(sensor_left.x), i32(sensor_left.y));
+                    let sensor_right_pos = vec2i(i32(sensor_right.x), i32(sensor_right.y));
+
+                    let sensor_front_color = textureLoad(trailMap, sensor_front_pos);
+                    let sensor_left_color = textureLoad(trailMap, sensor_left_pos);
+                    let sensor_right_color = textureLoad(trailMap, sensor_right_pos);
+
+                    let sensor_front_hsv = rgb2hsv(sensor_front_color.rgb);
+                    let sensor_left_hsv = rgb2hsv(sensor_left_color.rgb);
+                    let sensor_right_hsv = rgb2hsv(sensor_right_color.rgb);
+
+                    let color = vec4f(agents[gid].r, agents[gid].g, agents[gid].b, 0.0);
+                    let color_hsv = rgb2hsv(color.rgb);
+                    let sensor_front_v = abs(color_hsv.x - sensor_front_hsv.x);
+                    let sensor_left_v = abs(color_hsv.x - sensor_left_hsv.x);
+                    let sensor_right_v = abs(color_hsv.x - sensor_right_hsv.x);
+
+                    let rnd = hash(gid);
+                    let turningAngle = params.turningAngle;
+                    var new_angle = angle;
+
+                    if ((sensor_left_v < sensor_front_v) && (sensor_right_v < sensor_front_v)) {
+                        if (rnd < 0.5) {
+                            new_angle += turningAngle;
+                        } else {
+                            new_angle -= turningAngle;
+                        }
+                    } else if (sensor_right_v > sensor_left_v) {
+                        new_angle += turningAngle;
+                    } else if (sensor_left_v > sensor_right_v) {
+                        new_angle -= turningAngle;
+                    }
+
+                    let stepSize = params.stepSize;
+                    let new_position = vec2f(
+                        (agents[gid].x + stepSize * cos(new_angle)) % f32(width),
+                        (agents[gid].y + stepSize * sin(new_angle)) % f32(height)
+                    );
+                    let new_pixel = vec2i(i32(new_position.x), i32(new_position.y));
+
+                    let agentMapNewV = textureLoad(agentMap, new_pixel);
+                    let trailMapV = textureLoad(trailMap, pixel);
+
+                    let depositAmount = params.depositAmount;
+                    let full_color = vec4f(color.rgb, 1.0);
+                    let new_color = full_color * depositAmount;
+                    let new_value = trailMapV + new_color;
+
+                    textureStore(agentMapOut, new_pixel, agentMapNewV + vec4f(1.0));
+                    textureStore(trailMapOut, new_pixel, new_value);
+
+                    agents[gid].x = new_position.x;
+                    agents[gid].y = new_position.y;
+                    agents[gid].angle = new_angle;
+                }
+            `;
+
+            // Stage 1: Diffusion and decay
+            const computeShaderStage1 = shaderCommon + `
+                @compute @workgroup_size(${WORKGROUP_SIZE}, 1, 1)
+                fn main(@builtin(global_invocation_id) global_id: vec3u) {
+                    let gid = global_id.x;
+                    let width = u32(params.frameBufferWidth);
+                    let height = u32(params.frameBufferHeight);
+
+                    if (gid >= width * height) {
+                        return;
+                    }
+
+                    let y = i32(gid / width);
+                    let x = i32(gid % width);
+                    let k = i32(3 / 2);
+                    let n = pow(3.0, 2.0);
+                    var sum = vec4f(0.0);
+
+                    for (var i = -k; i <= k; i++) {
+                        for (var j = -k; j <= k; j++) {
+                            let pos_k = vec2i(
+                                i32((f32(x + i) % f32(width) + f32(width)) % f32(width)),
+                                i32((f32(y + j) % f32(height) + f32(height)) % f32(height))
+                            );
+                            sum += textureLoad(trailMap, pos_k);
+                        }
+                    }
+
+                    let pixel = vec2i(x, y);
+                    let decayAmount = 1.0 - params.decayAmount;
+                    let v = sum / n;
+                    textureStore(trailMapOut, pixel, v * decayAmount);
+                    textureStore(agentMapOut, pixel, vec4f(0.0));
+                }
+            `;
+
+            // Display shader
+            const displayShader = `
+                @group(0) @binding(0) var displayTexture: texture_2d<f32>;
+                @group(0) @binding(1) var displaySampler: sampler;
+
+                struct VertexOutput {
+                    @builtin(position) position: vec4f,
+                    @location(0) texCoord: vec2f,
+                }
 
                 @vertex
-                fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec4f {
+                fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOutput {
                     var pos = array<vec2f, 6>(
                         vec2f(-1.0, -1.0),
                         vec2f(1.0, -1.0),
@@ -128,66 +470,186 @@
                         vec2f(1.0, -1.0),
                         vec2f(1.0, 1.0)
                     );
-                    return vec4f(pos[vertexIndex], 0.0, 1.0);
+
+                    var texCoord = array<vec2f, 6>(
+                        vec2f(0.0, 1.0),
+                        vec2f(1.0, 1.0),
+                        vec2f(0.0, 0.0),
+                        vec2f(0.0, 0.0),
+                        vec2f(1.0, 1.0),
+                        vec2f(1.0, 0.0)
+                    );
+
+                    var output: VertexOutput;
+                    output.position = vec4f(pos[vertexIndex], 0.0, 1.0);
+                    output.texCoord = texCoord[vertexIndex];
+                    return output;
                 }
 
                 @fragment
-                fn fragmentMain(@builtin(position) pos: vec4f) -> @location(0) vec4f {
-                    let uv = pos.xy / vec2f(uniforms.width, uniforms.height);
-                    let t = uniforms.time * 0.0005;
-
-                    // Create flowing gradient
-                    let x = uv.x + sin(uv.y * 3.0 + t * 2.0) * 0.1;
-                    let y = uv.y + cos(uv.x * 3.0 + t * 1.5) * 0.1;
-
-                    let r = sin(x * 2.0 + t) * 0.5 + 0.5;
-                    let g = sin(y * 2.0 + t + 2.0) * 0.5 + 0.5;
-                    let b = sin((x + y) * 1.5 + t + 4.0) * 0.5 + 0.5;
-
-                    return vec4f(r * 0.6, g * 0.4, b * 0.8, 1.0);
+                fn fragmentMain(input: VertexOutput) -> @location(0) vec4f {
+                    return textureSample(displayTexture, displaySampler, input.texCoord);
                 }
             `;
 
-            const shaderModule = device.createShaderModule({ code: shaderCode });
+            // Create resources
+            let agentData = initAgents(simWidth, simHeight);
 
-            const pipeline = device.createRenderPipeline({
+            const agentBuffer = device.createBuffer({
+                size: agentData.byteLength,
+                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+            });
+            device.queue.writeBuffer(agentBuffer, 0, agentData);
+
+            const paramsBuffer = device.createBuffer({
+                size: 32, // 8 floats
+                usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+            });
+
+            function updateParams() {
+                const paramsData = new Float32Array([
+                    simWidth,
+                    simHeight,
+                    params.sensingDistance,
+                    params.sensingAngle,
+                    params.turningAngle,
+                    params.depositAmount,
+                    params.decayAmount,
+                    params.stepSize,
+                ]);
+                device.queue.writeBuffer(paramsBuffer, 0, paramsData);
+            }
+            updateParams();
+
+            // Create textures
+            const createTexture = () => device.createTexture({
+                size: [simWidth, simHeight],
+                format: 'rgba32float',
+                usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+            });
+
+            let agentMap = createTexture();
+            let agentMapOut = createTexture();
+            let trailMap = createTexture();
+            let trailMapOut = createTexture();
+
+            // Compile shaders
+            const computeModule0 = device.createShaderModule({ code: computeShaderStage0 });
+            const computeModule1 = device.createShaderModule({ code: computeShaderStage1 });
+            const displayModule = device.createShaderModule({ code: displayShader });
+
+            const computePipeline0 = device.createComputePipeline({
+                layout: 'auto',
+                compute: {
+                    module: computeModule0,
+                    entryPoint: 'main',
+                },
+            });
+
+            const computePipeline1 = device.createComputePipeline({
+                layout: 'auto',
+                compute: {
+                    module: computeModule1,
+                    entryPoint: 'main',
+                },
+            });
+
+            // Display pipeline
+            const displayPipeline = device.createRenderPipeline({
                 layout: 'auto',
                 vertex: {
-                    module: shaderModule,
+                    module: displayModule,
                     entryPoint: 'vertexMain',
                 },
                 fragment: {
-                    module: shaderModule,
+                    module: displayModule,
                     entryPoint: 'fragmentMain',
                     targets: [{ format }],
                 },
             });
 
-            // Create uniform buffer
-            const uniformBuffer = device.createBuffer({
-                size: 12, // 3 f32s
-                usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+            const sampler = device.createSampler({
+                magFilter: 'linear',
+                minFilter: 'linear',
             });
 
-            const bindGroup = device.createBindGroup({
-                layout: pipeline.getBindGroupLayout(0),
-                entries: [{
-                    binding: 0,
-                    resource: { buffer: uniformBuffer },
-                }],
-            });
+            function reset() {
+                agentData = initAgents(simWidth, simHeight);
+                device.queue.writeBuffer(agentBuffer, 0, agentData);
+
+                // Clear textures
+                agentMap = createTexture();
+                agentMapOut = createTexture();
+                trailMap = createTexture();
+                trailMapOut = createTexture();
+            }
+
+            setupControls(reset);
 
             // Animation loop
-            let startTime = Date.now();
+            let frameCount = 0;
+            let lastTime = performance.now();
+
             function render() {
-                const time = Date.now() - startTime;
-                const uniformData = new Float32Array([time, canvas.width, canvas.height]);
-                device.queue.writeBuffer(uniformBuffer, 0, uniformData);
+                updateParams();
 
-                const commandEncoder = device.createCommandEncoder();
+                const encoder = device.createCommandEncoder();
+
+                // Stage 0: Agent update
+                const bindGroup0 = device.createBindGroup({
+                    layout: computePipeline0.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: agentMap.createView() },
+                        { binding: 1, resource: agentMapOut.createView() },
+                        { binding: 2, resource: trailMap.createView() },
+                        { binding: 3, resource: trailMapOut.createView() },
+                        { binding: 4, resource: { buffer: paramsBuffer } },
+                        { binding: 5, resource: { buffer: agentBuffer } },
+                    ],
+                });
+
+                const computePass0 = encoder.beginComputePass();
+                computePass0.setPipeline(computePipeline0);
+                computePass0.setBindGroup(0, bindGroup0);
+                computePass0.dispatchWorkgroups(Math.ceil(AGENT_COUNT / WORKGROUP_SIZE));
+                computePass0.end();
+
+                // Swap agent maps
+                [agentMap, agentMapOut] = [agentMapOut, agentMap];
+
+                // Stage 1: Diffusion
+                const bindGroup1 = device.createBindGroup({
+                    layout: computePipeline1.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: agentMap.createView() },
+                        { binding: 1, resource: agentMapOut.createView() },
+                        { binding: 2, resource: trailMap.createView() },
+                        { binding: 3, resource: trailMapOut.createView() },
+                        { binding: 4, resource: { buffer: paramsBuffer } },
+                        { binding: 5, resource: { buffer: agentBuffer } },
+                    ],
+                });
+
+                const computePass1 = encoder.beginComputePass();
+                computePass1.setPipeline(computePipeline1);
+                computePass1.setBindGroup(0, bindGroup1);
+                computePass1.dispatchWorkgroups(Math.ceil((simWidth * simHeight) / WORKGROUP_SIZE));
+                computePass1.end();
+
+                // Swap trail maps
+                [trailMap, trailMapOut] = [trailMapOut, trailMap];
+
+                // Display pass
+                const displayBindGroup = device.createBindGroup({
+                    layout: displayPipeline.getBindGroupLayout(0),
+                    entries: [
+                        { binding: 0, resource: trailMap.createView() },
+                        { binding: 1, resource: sampler },
+                    ],
+                });
+
                 const textureView = context.getCurrentTexture().createView();
-
-                const renderPass = commandEncoder.beginRenderPass({
+                const renderPass = encoder.beginRenderPass({
                     colorAttachments: [{
                         view: textureView,
                         clearValue: { r: 0, g: 0, b: 0, a: 1 },
@@ -196,12 +658,22 @@
                     }],
                 });
 
-                renderPass.setPipeline(pipeline);
-                renderPass.setBindGroup(0, bindGroup);
+                renderPass.setPipeline(displayPipeline);
+                renderPass.setBindGroup(0, displayBindGroup);
                 renderPass.draw(6);
                 renderPass.end();
 
-                device.queue.submit([commandEncoder.finish()]);
+                device.queue.submit([encoder.finish()]);
+
+                // FPS counter
+                frameCount++;
+                const now = performance.now();
+                if (now - lastTime >= 1000) {
+                    document.getElementById('fps').textContent = frameCount;
+                    frameCount = 0;
+                    lastTime = now;
+                }
+
                 requestAnimationFrame(render);
             }
 
@@ -209,14 +681,13 @@
         }
 
         function showError(message) {
-            document.querySelector('.overlay').style.display = 'none';
-            document.body.insertAdjacentHTML('beforeend', `
+            document.body.innerHTML += `
                 <div class="error">
                     <h2>WebGPU Not Available</h2>
                     <p>${message}</p>
                     <p style="margin-top: 1rem;">WebGPU requires a modern browser with GPU support enabled.</p>
                 </div>
-            `);
+            `;
         }
 
         initWebGPU().catch(err => {


### PR DESCRIPTION
- Translate GLSL compute shader from ComputeShader repo to WGSL
- Create two-stage compute pipeline (agent update + diffusion/decay)
- Add 262k agents with hue-based sensing and colored trails
- Implement storage buffers for agents and parameters
- Add texture ping-pong for agentMap and trailMap
- Create interactive controls for all simulation parameters
- Add FPS counter and reset functionality
- Use 1920x1080 simulation resolution with full-screen display