### PR TITLE
Align parameters and trail deposition with reference implementation

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,10 +7,11 @@ export const SIM_WIDTH = 1920;
 export const SIM_HEIGHT = 1080;
 
 // Default simulation parameters
+// Note: angles are stored in radians internally but displayed as degrees in UI
 export const params = {
-    sensingDistance: 20,
-    sensingAngle: 0.52,
-    turningAngle: 0.52,
+    sensingDistance: 10.0,
+    sensingAngle: 0.7853981633974483,  // 45 degrees
+    turningAngle: 0.7853981633974483,   // 45 degrees
     depositAmount: 0.10,
     decayAmount: 0.10,
     stepSize: 1.0

--- a/controls.js
+++ b/controls.js
@@ -1,6 +1,15 @@
 import { params } from './config.js';
 
 /**
+ * Convert degrees to radians
+ * @param {number} degrees - Angle in degrees
+ * @returns {number} Angle in radians
+ */
+function degreesToRadians(degrees) {
+    return degrees * Math.PI / 180;
+}
+
+/**
  * Setup UI controls for simulation parameters
  * @param {Function} resetCallback - Callback function for reset button
  */
@@ -12,8 +21,16 @@ export function setupControls(resetCallback) {
         const slider = document.getElementById(name);
         const valueDisplay = document.getElementById(name + 'Value');
         slider.addEventListener('input', (e) => {
-            params[name] = parseFloat(e.target.value);
-            valueDisplay.textContent = params[name].toFixed(2);
+            const value = parseFloat(e.target.value);
+
+            // Convert degrees to radians for angle parameters
+            if (name === 'sensingAngle' || name === 'turningAngle') {
+                params[name] = degreesToRadians(value);
+                valueDisplay.textContent = value.toFixed(1);
+            } else {
+                params[name] = value;
+                valueDisplay.textContent = value.toFixed(2);
+            }
         });
     });
 

--- a/index.html
+++ b/index.html
@@ -13,23 +13,23 @@
         <h2>Slime Mould</h2>
 
         <div class="control-group">
-            <label>Sensing Distance: <span class="value" id="sensingDistanceValue">20</span></label>
-            <input type="range" id="sensingDistance" min="5" max="100" value="20" step="1">
+            <label>Sensing Distance: <span class="value" id="sensingDistanceValue">10.0</span></label>
+            <input type="range" id="sensingDistance" min="0" max="256" value="10" step="1">
         </div>
 
         <div class="control-group">
-            <label>Sensing Angle: <span class="value" id="sensingAngleValue">0.52</span></label>
-            <input type="range" id="sensingAngle" min="0" max="3.14" value="0.52" step="0.01">
+            <label>Sensing Angle: <span class="value" id="sensingAngleValue">45.0</span>°</label>
+            <input type="range" id="sensingAngle" min="0" max="180" value="45" step="1">
         </div>
 
         <div class="control-group">
-            <label>Turning Angle: <span class="value" id="turningAngleValue">0.52</span></label>
-            <input type="range" id="turningAngle" min="0" max="3.14" value="0.52" step="0.01">
+            <label>Turning Angle: <span class="value" id="turningAngleValue">45.0</span>°</label>
+            <input type="range" id="turningAngle" min="0" max="360" value="45" step="1">
         </div>
 
         <div class="control-group">
             <label>Deposit Amount: <span class="value" id="depositAmountValue">0.10</span></label>
-            <input type="range" id="depositAmount" min="0" max="1" value="0.10" step="0.01">
+            <input type="range" id="depositAmount" min="0.01" max="1" value="0.10" step="0.01">
         </div>
 
         <div class="control-group">
@@ -39,7 +39,7 @@
 
         <div class="control-group">
             <label>Step Size: <span class="value" id="stepSizeValue">1.0</span></label>
-            <input type="range" id="stepSize" min="0.1" max="5" value="1.0" step="0.1">
+            <input type="range" id="stepSize" min="0" max="100" value="1.0" step="0.1">
         </div>
 
         <button id="resetButton">Reset Simulation</button>

--- a/shaders.js
+++ b/shaders.js
@@ -131,12 +131,12 @@ fn main(@builtin(global_invocation_id) global_id: vec3u) {
     let new_pixel = vec2i(i32(new_position.x), i32(new_position.y));
 
     let agentMapNewV = textureLoad(agentMap, new_pixel);
-    let trailMapNewV = textureLoad(trailMap, new_pixel);
+    let trailMapV = textureLoad(trailMap, pixel);  // Read from OLD position
 
     let depositAmount = params.depositAmount;
     let full_color = vec4f(color.rgb, 1.0);
     let new_color = full_color * depositAmount;
-    let new_value = trailMapNewV + new_color;
+    let new_value = trailMapV + new_color;  // Use trail value from OLD position
 
     textureStore(agentMapOut, new_pixel, agentMapNewV + vec4f(1.0));
     textureStore(trailMapOut, new_pixel, new_value);


### PR DESCRIPTION
This commit addresses two key differences identified in the review:

1. **Parameter Ranges and Units**:
   - Sensing Distance: 0-256 (was 5-100)
   - Sensing Angle: 0-180° (was 0-3.14 radians in UI)
   - Turning Angle: 0-360° (was 0-3.14 radians in UI)
   - Deposit Amount: 0.01-1.0 (was 0-1.0)
   - Step Size: 0-100 (was 0.1-5)
   - UI now displays angles in degrees while storing radians internally
   - Initial values updated to match reference (sensing/turning angles: 45°, sensing distance: 10)

2. **Trail Deposition Logic**:
   - Fixed to read trail value from OLD agent position (not NEW)
   - Agent now deposits trail based on where it WAS, not where it's going
   - This matches the reference GLSL implementation behavior
   - Affects trail accumulation when multiple agents occupy same cell

These changes bring the WebGPU implementation closer to the reference Java/LWJGL/OpenGL implementation while maintaining browser performance optimizations (agent count, texture precision).